### PR TITLE
feat: allow excluding namespaces fromCoreDNS rewrites.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,8 @@ linters:
     - unparam
     - unused
   settings:
+    cyclop:
+      max-complexity: 32
     revive:
       rules:
         - name: comment-spacings

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,8 +22,8 @@ linters:
     - unparam
     - unused
   settings:
-    cyclop:
-      max-complexity: 32
+    gocyclo:
+      min-complexity: 32
     revive:
       rules:
         - name: comment-spacings

--- a/charts/kic/README.md
+++ b/charts/kic/README.md
@@ -15,7 +15,8 @@ A Helm chart for Kubernetes Image Cacher (kic)
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| controllerManager | object | `{"enableHttp2":false,"health":{"bindAddress":":8081"},"ingressAnnotation":"","ingressControllerService":"controller.nginx.svc.cluster.local","leaderElect":false,"metrics":{"bindAddress":":8080","secure":false},"watchedNamespaces":""}` | Controller manager specific settings |
+| controllerManager | object | `{"corednsExcludedNamespaces":"","enableHttp2":false,"health":{"bindAddress":":8081"},"ingressAnnotation":"","ingressControllerService":"controller.nginx.svc.cluster.local","leaderElect":false,"metrics":{"bindAddress":":8080","secure":false},"watchedNamespaces":""}` | Controller manager specific settings |
+| controllerManager.corednsExcludedNamespaces | string | `""` | Comma-separated list of namespaces to ignore custom rewrite rules. |
 | controllerManager.enableHttp2 | bool | `false` | Enable HTTP2 for metrics and webhook servers. |
 | controllerManager.health | object | `{"bindAddress":":8081"}` | Health probe settings |
 | controllerManager.health.bindAddress | string | `":8081"` | Address to bind health probe endpoint to. |

--- a/charts/kic/README.md
+++ b/charts/kic/README.md
@@ -15,13 +15,13 @@ A Helm chart for Kubernetes Image Cacher (kic)
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |
 | autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
-| controllerManager | object | `{"corednsExcludedNamespaces":"","enableHttp2":false,"health":{"bindAddress":":8081"},"ingressAnnotation":"","ingressControllerService":"controller.nginx.svc.cluster.local","leaderElect":false,"metrics":{"bindAddress":":8080","secure":false},"watchedNamespaces":""}` | Controller manager specific settings |
+| controllerManager | object | `{"corednsExcludedNamespaces":"","enableHttp2":false,"health":{"bindAddress":":8081"},"ingressAnnotation":"","ingressControllerService":"ingress-nginx-controller.ingress-nginx.svc.cluster.local","leaderElect":false,"metrics":{"bindAddress":":8080","secure":false},"watchedNamespaces":""}` | Controller manager specific settings |
 | controllerManager.corednsExcludedNamespaces | string | `""` | Comma-separated list of namespaces to ignore custom rewrite rules. |
 | controllerManager.enableHttp2 | bool | `false` | Enable HTTP2 for metrics and webhook servers. |
 | controllerManager.health | object | `{"bindAddress":":8081"}` | Health probe settings |
 | controllerManager.health.bindAddress | string | `":8081"` | Address to bind health probe endpoint to. |
 | controllerManager.ingressAnnotation | string | `""` | Annotation to look for on Ingresses. Empty means all Ingresses. |
-| controllerManager.ingressControllerService | string | `"controller.nginx.svc.cluster.local"` | Fully qualified domain name of the ingress controller service. |
+| controllerManager.ingressControllerService | string | `"ingress-nginx-controller.ingress-nginx.svc.cluster.local"` | Fully qualified domain name of the ingress controller service. |
 | controllerManager.metrics | object | `{"bindAddress":":8080","secure":false}` | Metrics settings |
 | controllerManager.metrics.bindAddress | string | `":8080"` | Address to bind metrics endpoint to. Set to "0" to disable. |
 | controllerManager.metrics.secure | bool | `false` | Whether to serve metrics securely (HTTPS). Requires certs if true and bindAddress is not "0". |

--- a/charts/kic/templates/deployment.yaml
+++ b/charts/kic/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
             {{- if .Values.controllerManager.watchedNamespaces }}
             - "--watched-namespaces={{ .Values.controllerManager.watchedNamespaces }}"
             {{- end }}
+            {{- if .Values.controllerManager.corednsExcludedNamespaces }}
+            - "--coredns-excluded-namespaces={{ .Values.controllerManager.corednsExcludedNamespaces }}"
+            {{- end }}
             {{- if .Values.controllerManager.ingressAnnotation }}
             - "--ingress-annotation={{ .Values.controllerManager.ingressAnnotation }}"
             {{- end }}

--- a/charts/kic/values.yaml
+++ b/charts/kic/values.yaml
@@ -43,6 +43,8 @@ controllerManager:
     bindAddress: ":8081" # Default from main.go
   # -- Comma-separated list of namespaces to watch. Empty means all namespaces.
   watchedNamespaces: ""
+  # -- Comma-separated list of namespaces to ignore custom rewrite rules.
+  corednsExcludedNamespaces: ""
   # -- Annotation to look for on Ingresses. Empty means all Ingresses.
   ingressAnnotation: ""
   # -- Fully qualified domain name of the ingress controller service.

--- a/charts/kic/values.yaml
+++ b/charts/kic/values.yaml
@@ -48,7 +48,7 @@ controllerManager:
   # -- Annotation to look for on Ingresses. Empty means all Ingresses.
   ingressAnnotation: ""
   # -- Fully qualified domain name of the ingress controller service.
-  ingressControllerService: "controller.nginx.svc.cluster.local" # Default from main.go
+  ingressControllerService: "ingress-nginx-controller.ingress-nginx.svc.cluster.local" # Default from main.go
   # -- Enable HTTP2 for metrics and webhook servers.
   enableHttp2: false
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,7 +92,7 @@ func main() {
 		"A comma-separated list of namespaces to watch for Ingresses. If empty, all namespaces are watched.")
 	flag.StringVar(&ingressAnnotation, "ingress-annotation", "",
 		"The annotation to look for on Ingresses. If not set, all Ingresses are considered.")
-	flag.StringVar(&ingressControllerService, "ingress-controller-service", "controller.nginx.svc.cluster.local",
+	flag.StringVar(&ingressControllerService, "ingress-controller-service", "ingress-nginx-controller.ingress-nginx.svc.cluster.local",
 		"The fully qualified domain name of the ingress controller service.")
 	flag.StringVar(&coreDNSExcludedNamespaces, "coredns-excluded-namespaces", "",
 		"A comma-separated list of namespaces to exclude from CoreDNS rewrite rules.")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,7 +92,8 @@ func main() {
 		"A comma-separated list of namespaces to watch for Ingresses. If empty, all namespaces are watched.")
 	flag.StringVar(&ingressAnnotation, "ingress-annotation", "",
 		"The annotation to look for on Ingresses. If not set, all Ingresses are considered.")
-	flag.StringVar(&ingressControllerService, "ingress-controller-service", "ingress-nginx-controller.ingress-nginx.svc.cluster.local",
+	flag.StringVar(&ingressControllerService, "ingress-controller-service",
+		"ingress-nginx-controller.ingress-nginx.svc.cluster.local",
 		"The fully qualified domain name of the ingress controller service.")
 	flag.StringVar(&coreDNSExcludedNamespaces, "coredns-excluded-namespaces", "",
 		"A comma-separated list of namespaces to exclude from CoreDNS rewrite rules.")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,6 +68,7 @@ func main() {
 	var watchedNamespaces string
 	var ingressAnnotation string
 	var ingressControllerService string
+	var coreDNSExcludedNamespaces string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -93,6 +94,8 @@ func main() {
 		"The annotation to look for on Ingresses. If not set, all Ingresses are considered.")
 	flag.StringVar(&ingressControllerService, "ingress-controller-service", "controller.nginx.svc.cluster.local",
 		"The fully qualified domain name of the ingress controller service.")
+	flag.StringVar(&coreDNSExcludedNamespaces, "coredns-excluded-namespaces", "",
+		"A comma-separated list of namespaces to exclude from CoreDNS rewrite rules.")
 
 	opts := zap.Options{
 		Development: true,
@@ -224,12 +227,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	var excludedNS []string
+	if coreDNSExcludedNamespaces != "" {
+		excludedNS = strings.Split(coreDNSExcludedNamespaces, ",")
+		for i := range excludedNS {
+			excludedNS[i] = strings.TrimSpace(excludedNS[i])
+		}
+	}
+
 	if err = (&controller.IngressReconciler{
 		Client:                       mgr.GetClient(),
 		Scheme:                       mgr.GetScheme(),
 		Log:                          ctrl.Log.WithName("controllers").WithName("Ingress"),
 		IngressAnnotation:            ingressAnnotation,
 		IngressControllerServiceName: ingressControllerService,
+		CoreDNSExcludedNamespaces:    excludedNS,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Ingress")
 		os.Exit(1)

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,20 +27,24 @@ make deploy
 
 The controller accepts the following command-line parameters:
 
-| Parameter                      | Description                                                                                                  | Default Value                        |
-| ------------------------------ |--------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| Parameter                      | Description                                                                                                 | Default Value                        |
+| ------------------------------ |-------------------------------------------------------------------------------------------------------------|--------------------------------------|
 | `metrics-bind-address`         | The address the metrics endpoint binds to. Use `:8443` for HTTPS or `:8080` for HTTP. Set to `0` to disable. | `0`                                  |
-| `health-probe-bind-address`    | The address the health probe endpoint binds to.                                                              | `:8081`                              |
-| `leader-elect`                 | Enable leader election for controller manager. Ensures only one active controller manager.                   | `false`                              |
-| `metrics-secure`               | If `true`, the metrics endpoint is served securely via HTTPS. Set to `false` for HTTP.                       | `true`                               |
-| `webhook-cert-path`            | Directory containing the webhook certificate.                                                                | `""`                                 |
-| `webhook-cert-name`            | Name of the webhook certificate file.                                                                        | `tls.crt`                            |
-| `webhook-cert-key`             | Name of the webhook key file.                                                                                | `tls.key`                            |
-| `metrics-cert-path`            | Directory containing the metrics server certificate.                                                         | `""`                                 |
-| `metrics-cert-name`            | Name of the metrics server certificate file.                                                                 | `tls.crt`                            |
-| `metrics-cert-key`             | Name of the metrics server key file.                                                                         | `tls.key`                            |
-| `enable-http2`                 | If `true`, HTTP/2 will be enabled for the metrics and webhook servers.                                       | `false`                              |
-| `watched-namespaces`           | Comma-separated list of namespaces to watch for Ingresses. If empty, all namespaces are watched.             | `""`                                 |
-| `ingress-annotation`           | Annotation to look for on Ingresses. If not set, all Ingresses are considered.                               | `""`                                 |
-| `ingress-controller-service`   | Fully qualified domain name of the ingress controller service.                                               | `controller.nginx.svc.cluster.local` |
-| `coredns-excluded-namespaces`   | Comma-separated list of namespaces for that will skip rewrite rules.                                         | `""`                                 |
+| `health-probe-bind-address`    | The address the health probe endpoint binds to.                                                             | `:8081`                              |
+| `leader-elect`                 | Enable leader election for controller manager. Ensures only one active controller manager.                  | `false`                              |
+| `metrics-secure`               | If `true`, the metrics endpoint is served securely via HTTPS. Set to `false` for HTTP.                      | `true`                               |
+| `webhook-cert-path`            | Directory containing the webhook certificate.                                                               | `""`                                 |
+| `webhook-cert-name`            | Name of the webhook certificate file.                                                                       | `tls.crt`                            |
+| `webhook-cert-key`             | Name of the webhook key file.                                                                               | `tls.key`                            |
+| `metrics-cert-path`            | Directory containing the metrics server certificate.                                                        | `""`                                 |
+| `metrics-cert-name`            | Name of the metrics server certificate file.                                                                | `tls.crt`                            |
+| `metrics-cert-key`             | Name of the metrics server key file.                                                                        | `tls.key`                            |
+| `enable-http2`                 | If `true`, HTTP/2 will be enabled for the metrics and webhook servers.                                      | `false`                              |
+| `watched-namespaces`           | Comma-separated list of namespaces to watch for Ingresses. If empty, all namespaces are watched.            | `""`                                 |
+| `ingress-annotation`           | Annotation to look for on Ingresses. If not set, all Ingresses are considered.                              | `""`                                 |
+| `ingress-controller-service`   | Fully qualified domain name of the ingress controller service.                                              | `controller.nginx.svc.cluster.local` |
+| `coredns-excluded-namespaces`   | Comma-separated list of namespaces for that will skip rewrite rules. common=cert-manager                    | `""`                                 |
+
+### coredns-excluded-namespaces use
+
+cert-manager needs to be excluded from the rewrite rules as it will cause a scenerio where the dns check never succeed and you want it to check the exteral dns

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,19 +27,20 @@ make deploy
 
 The controller accepts the following command-line parameters:
 
-| Parameter                      | Description                                                                                          | Default Value                          |
-| ------------------------------ | ---------------------------------------------------------------------------------------------------- | -------------------------------------- |
-| `metrics-bind-address`         | The address the metrics endpoint binds to. Use `:8443` for HTTPS or `:8080` for HTTP. Set to `0` to disable. | `0`                                    |
-| `health-probe-bind-address`    | The address the health probe endpoint binds to.                                                        | `:8081`                                |
-| `leader-elect`                 | Enable leader election for controller manager. Ensures only one active controller manager.             | `false`                                |
-| `metrics-secure`               | If `true`, the metrics endpoint is served securely via HTTPS. Set to `false` for HTTP.                 | `true`                                 |
-| `webhook-cert-path`            | Directory containing the webhook certificate.                                                          | `""`                                   |
-| `webhook-cert-name`            | Name of the webhook certificate file.                                                                  | `tls.crt`                              |
-| `webhook-cert-key`             | Name of the webhook key file.                                                                          | `tls.key`                              |
-| `metrics-cert-path`            | Directory containing the metrics server certificate.                                                   | `""`                                   |
-| `metrics-cert-name`            | Name of the metrics server certificate file.                                                           | `tls.crt`                              |
-| `metrics-cert-key`             | Name of the metrics server key file.                                                                   | `tls.key`                              |
-| `enable-http2`                 | If `true`, HTTP/2 will be enabled for the metrics and webhook servers.                                 | `false`                                |
-| `watched-namespaces`           | Comma-separated list of namespaces to watch for Ingresses. If empty, all namespaces are watched.       | `""`                                   |
-| `ingress-annotation`           | Annotation to look for on Ingresses. If not set, all Ingresses are considered.                         | `""`                                   |
-| `ingress-controller-service`   | Fully qualified domain name of the ingress controller service.                                       | `controller.nginx.svc.cluster.local` |
+| Parameter                      | Description                                                                                                  | Default Value                        |
+| ------------------------------ |--------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| `metrics-bind-address`         | The address the metrics endpoint binds to. Use `:8443` for HTTPS or `:8080` for HTTP. Set to `0` to disable. | `0`                                  |
+| `health-probe-bind-address`    | The address the health probe endpoint binds to.                                                              | `:8081`                              |
+| `leader-elect`                 | Enable leader election for controller manager. Ensures only one active controller manager.                   | `false`                              |
+| `metrics-secure`               | If `true`, the metrics endpoint is served securely via HTTPS. Set to `false` for HTTP.                       | `true`                               |
+| `webhook-cert-path`            | Directory containing the webhook certificate.                                                                | `""`                                 |
+| `webhook-cert-name`            | Name of the webhook certificate file.                                                                        | `tls.crt`                            |
+| `webhook-cert-key`             | Name of the webhook key file.                                                                                | `tls.key`                            |
+| `metrics-cert-path`            | Directory containing the metrics server certificate.                                                         | `""`                                 |
+| `metrics-cert-name`            | Name of the metrics server certificate file.                                                                 | `tls.crt`                            |
+| `metrics-cert-key`             | Name of the metrics server key file.                                                                         | `tls.key`                            |
+| `enable-http2`                 | If `true`, HTTP/2 will be enabled for the metrics and webhook servers.                                       | `false`                              |
+| `watched-namespaces`           | Comma-separated list of namespaces to watch for Ingresses. If empty, all namespaces are watched.             | `""`                                 |
+| `ingress-annotation`           | Annotation to look for on Ingresses. If not set, all Ingresses are considered.                               | `""`                                 |
+| `ingress-controller-service`   | Fully qualified domain name of the ingress controller service.                                               | `controller.nginx.svc.cluster.local` |
+| `coredns-excluded-namespaces`   | Comma-separated list of namespaces for that will skip rewrite rules.                                         | `""`                                 |

--- a/internal/controller/ingress_controller_coredns_test.go
+++ b/internal/controller/ingress_controller_coredns_test.go
@@ -291,6 +291,59 @@ func TestInjectRewriteRules(t *testing.T) {
 				"    health\n" +
 				"}\n",
 		},
+		{
+			name: "corefile without metadata, with expression rules",
+			corefile: ".:53 {\n" +
+				"    errors\n" +
+				"    health\n" +
+				"    kubernetes cluster.local in-addr.arpa ip6.arpa {\n" +
+				"        pods insecure\n" +
+				"    }\n" +
+				"}\n",
+			newRules: "expression \"!(label('kubernetes/client-namespace') in ['kube-system'])\" {\n" +
+				"    rewrite name host1 service1\n" +
+				"}",
+			expectedCorefile: ".:53 {\n" +
+				"    errors\n" +
+				"    health\n" +
+				"    metadata\n" +
+				managedRulesBeginMarker + "\n" +
+				"expression \"!(label('kubernetes/client-namespace') in ['kube-system'])\" {\n" +
+				"    rewrite name host1 service1\n" +
+				"}\n" +
+				managedRulesEndMarker + "\n" +
+				"    kubernetes cluster.local in-addr.arpa ip6.arpa {\n" +
+				"        pods insecure\n" +
+				"    }\n" +
+				"}\n",
+		},
+		{
+			name: "corefile with metadata, with expression rules",
+			corefile: ".:53 {\n" +
+				"    errors\n" +
+				"    health\n" +
+				"    metadata\n" +
+				"    kubernetes cluster.local in-addr.arpa ip6.arpa {\n" +
+				"        pods insecure\n" +
+				"    }\n" +
+				"}\n",
+			newRules: "expression \"!(label('kubernetes/client-namespace') in ['kube-system'])\" {\n" +
+				"    rewrite name host1 service1\n" +
+				"}",
+			expectedCorefile: ".:53 {\n" +
+				"    errors\n" +
+				"    health\n" +
+				"    metadata\n" +
+				managedRulesBeginMarker + "\n" +
+				"expression \"!(label('kubernetes/client-namespace') in ['kube-system'])\" {\n" +
+				"    rewrite name host1 service1\n" +
+				"}\n" +
+				managedRulesEndMarker + "\n" +
+				"    kubernetes cluster.local in-addr.arpa ip6.arpa {\n" +
+				"        pods insecure\n" +
+				"    }\n" +
+				"}\n",
+		},
 	}
 
 	r := &IngressReconciler{} // Dummy reconciler for this test


### PR DESCRIPTION
I added a new `--coredns-excluded-namespaces` flag to the manager. When you provide it, DNS requests originating from these namespaces will not be rewritten.

I implemented this by wrapping the CoreDNS rewrite rules in an `expression` plugin block, which uses a CEL expression to check the client's namespace. I also ensured the `metadata` plugin is automatically injected into the Corefile if it's not already present.