### PR TITLE
fix: Invert order of coredns config updates

### DIFF
--- a/internal/controller/ingress_controller.go
+++ b/internal/controller/ingress_controller.go
@@ -232,13 +232,35 @@ func (r *IngressReconciler) injectRewriteRules(corefileContent string, newRules 
 
 	// 3. Ensure the 'metadata' plugin is present if needed.
 	needsMetadata := strings.Contains(newRules, "expression")
-	// Check the updated content for the metadata plugin.
 	hasMetadata := strings.Contains(updatedCorefile, "metadata")
 
 	finalCorefile := updatedCorefile
 	if needsMetadata && !hasMetadata {
-		// If metadata is needed but not present, inject it before our managed block.
-		finalCorefile = strings.Replace(updatedCorefile, managedRulesBeginMarker, "    metadata\n"+managedRulesBeginMarker, 1)
+		// If metadata is needed but not present, inject it before the kubernetes plugin.
+		lines := strings.Split(updatedCorefile, "\n")
+		kubernetesLine := -1
+		for i, line := range lines {
+			if strings.Contains(line, "kubernetes") {
+				kubernetesLine = i
+				break
+			}
+		}
+
+		if kubernetesLine != -1 {
+			var builder strings.Builder
+			builder.WriteString(strings.Join(lines[:kubernetesLine], "\n"))
+			if builder.Len() > 0 {
+				builder.WriteString("\n")
+			}
+			// Inject metadata with the same indentation as the kubernetes line.
+			indent := strings.Repeat(" ", len(lines[kubernetesLine])-len(strings.TrimLeft(lines[kubernetesLine], " ")))
+			builder.WriteString(indent + "metadata\n")
+			builder.WriteString(strings.Join(lines[kubernetesLine:], "\n"))
+			finalCorefile = builder.String()
+		} else {
+			// Fallback: if kubernetes plugin is not found, inject it before the managed block.
+			finalCorefile = strings.Replace(updatedCorefile, managedRulesBeginMarker, "    metadata\n"+managedRulesBeginMarker, 1)
+		}
 	}
 
 	// 4. Normalize and return the final content.

--- a/internal/controller/ingress_controller_coredns_test.go
+++ b/internal/controller/ingress_controller_coredns_test.go
@@ -306,10 +306,10 @@ func TestInjectRewriteRules(t *testing.T) {
 			expectedCorefile: ".:53 {\n" +
 				"    errors\n" +
 				"    health\n" +
+				"    metadata\n" +
 				"    kubernetes cluster.local in-addr.arpa ip6.arpa {\n" +
 				"        pods insecure\n" +
 				"    }\n" +
-				"    metadata\n" +
 				managedRulesBeginMarker + "\n" +
 				"expression \"!(label('kubernetes/client-namespace') in ['kube-system'])\" {\n" +
 				"    rewrite name host1 service1\n" +


### PR DESCRIPTION
When the ingress controller updates the coredns config with the rewrite rules, it now applies them after the kubernetes block instead of before. This ensures that the kubernetes plugin is processed first, which is the desired behavior.